### PR TITLE
Adding Docker Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secrets.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:8
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN echo 'force-unsafe-io' | tee /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
+    echo 'DPkg::Post-Invoke {"/bin/rm -f /var/cache/apt/archives/*.deb || true";};' | tee /etc/apt/apt.conf.d/no-cache && \
+    echo 'Acquire::http {No-Cache=True;};' | tee /etc/apt/apt.conf.d/no-http-cache
+
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        libffi-dev \
+        && apt-get clean
+
+RUN apt-get install -y \
+        python3 \
+        python3-dev \
+        python3-pip \
+	python3-setuptools \
+        && apt-get clean
+
+
+RUN apt-get install -y \
+        libfuzzy-dev ssdeep \
+        && apt-get clean
+
+
+RUN pip3 install --upgrade pip setuptools
+
+COPY . /code
+
+RUN pip3 install -r /code/requirements.txt
+
+CMD /code/gitgot.py -q SEARCH-HERE

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ For Windows or *nix distributions without the `ssdeep` package, please see the [
 pip3 install -r requirements.txt
 ```
 
+For docker, clone the repository and add a `secrets.env` file with your github access token binded to `GITHUB_ACCESS_TOKEN`. The file might look like this:
+```
+GITHUB_ACCESS_TOKEN=<MY-ACCESS-TOKEN>
+```
+
+Then edit the `CMD` at the bottom of the Dockerfile to be whatever you want to search for. Build and run with the following:
+```shell
+docker built -t gitgot:dev .
+docker run --env-file secrets.env -it gitgot:dev
+```
+
 ## Usage
 
 GitHub requires a token for rate-limiting purposes. Create a [GitHub API token](https://github.com/settings/tokens) with **no permissions/no scope**. This will be equivalent to public GitHub access, but it will allow access to use the GitHub Search API. Set this token at the top of `gitgot.py` as shown below:

--- a/gitgot.py
+++ b/gitgot.py
@@ -15,7 +15,6 @@ import urllib.parse
 SIMILARITY_THRESHOLD = 65
 ACCESS_TOKEN = "<NO-PERMISSION-GITHUB-TOKEN-HERE>"
 
-
 class bcolors:
     """ Thank you Blender scripts :) """
     HEADER = '\033[95m'
@@ -285,7 +284,8 @@ def api_request_loop(state):
 
 
 def regex_validator(args, state):
-    with open(args.checks, "r") as fd:
+    ospath = os.path.dirname(os.path.realpath(__file__)) + '/'
+    with open(ospath + args.checks, "r") as fd:
         for line in fd.read().splitlines():
             if line.startswith("#") or len(line) == 0:
                 continue


### PR DESCRIPTION
# Purpose
ssdeep is a hassle to install on systems and the configuration can take way too long. Using docker, we can run this on a container platform in the cloud or even locally as a service. Logging results is easy with the docker logging driver.

# Changes
### Adding:
- `Dockerfile`
- `.gitignore`

### Changes:
- `README.md`
  - Adding docker instructions for building and running
- `gitgot.py`
  - Adding fully qualified path to line 288 if user is not running python file from current directory