### PR TITLE
Fixed GithubException API handling to prevent crashing

### DIFF
--- a/gitgot.py
+++ b/gitgot.py
@@ -141,7 +141,8 @@ def should_parse(repo, state, is_gist=False):
                     bcolors.ENDC)
                 return False
     except github.GithubException as e:
-        print(bcolors.FAIL + "API ERROR: " + e + bcolors.ENDC)
+        print(bcolors.FAIL + "API ERROR: {}".format(e) + bcolors.ENDC)
+        return False
     return True
 
 


### PR DESCRIPTION
#### Card

`GithubException` Causes File Crash

#### Details

Adding a small fix to properly handle the `GithubException` for the API errors by formatting the print statement and returning `False` to skip the specific commit and continue normal operations. Without this, the program crashes when GitHub returns something like a 404 Error when the commit is not found.