### PR TITLE
Update dependencies and fix Python 3.11+ deprecations

### DIFF
--- a/gitgot.py
+++ b/gitgot.py
@@ -513,9 +513,9 @@ def main():
 
     if args.url:
         g = github.Github(base_url=args.url + "/api/v3",
-                          login_or_token=ACCESS_TOKEN)
+                          auth=github.Auth.Token(ACCESS_TOKEN))
     else:
-        g = github.Github(ACCESS_TOKEN)
+        g = github.Github(auth=github.Auth.Token(ACCESS_TOKEN))
 
 
     if state.is_gist:

--- a/gitgot.py
+++ b/gitgot.py
@@ -7,8 +7,7 @@ import json
 import re
 import requests
 import sys
-import ssdeep
-import sre_constants
+import ppdeep as ssdeep
 import os
 import os.path
 import urllib.parse
@@ -398,7 +397,7 @@ def regex_validator(args, state):
                 continue
             try:
                 re.subn(line, r'\1', "Expression test")
-            except sre_constants.error as e:
+            except re.error as e:
                 print(bcolors.FAIL + "Invalid Regular expression:\n\t" + line)
                 if "group" in str(e):
                     print(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4
 PyGithub
-ssdeep
+ppdeep


### PR DESCRIPTION
Replace ssdeep with ppdeep  
The ssdeep Python package requires libfuzzy-dev and fails to build on Python 3.13 due to its setup.py depending on the removed pkg_resources module.

Updated requirements.txt and aliased the import (import ppdeep as ssdeep) so all existing call sites work unchanged.
Replace deprecated sre_constants 
sre_constants was deprecated in Python 3.11. Removed the import and replaced sre_constants.error with re.error, which is the same exception class.
Replace deprecated login_or_token kwarg  
PyGithub 2.x deprecated login_or_token in favor of auth=github.Auth.Token(...). Updated both the default and self-hosted GitHub instance constructors.